### PR TITLE
Changes from switching to macbook m1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ PYTHON BACKEND SERVER
 
 This runs the python fastapi backend server locally
 -Go to python dir and then run this command, uvicorn fastApi:app --reload
+    may have to run python or python3 -m vicorn fastApi:app --reload

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ sniffio==1.3.0
 starlette==0.26.1
 typing_extensions==4.5.0
 ujson==5.7.0
-urllib3==2.0.2
+urllib3==2.0.0
 uvicorn==0.22.0
 uvloop==0.17.0
 watchfiles==0.19.0


### PR DESCRIPTION
Changed requirements file to have a urllib3 version that has to be less than 2.0 otherwise uvicorn server wont run properly. Also python command change to run the uvicorn fastapi server.